### PR TITLE
Fix `sdk_token` method name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ with Onfido's SDKs.
 ```python
 request_body = {"applicant_id": "<APPLICANT_ID>", "application_id": "<APPLICATION_ID>"}
 
-api.sdk_token.create(request_body) # => Creates an SDK token
+api.sdk_token.generate(request_body) # => Creates an SDK token
 ```
 
 ### Error Handling


### PR DESCRIPTION
This has properly caught me out and had to dig in the source code to find out what's the right method to call.

This does make `sdk_token` a bit inconsistent with the rest of the resources, so I guess as an alternative the method itself could be renamed?