### PR TITLE
OnfidoRequestError: Propagate error to exception

### DIFF
--- a/onfido/exceptions.py
+++ b/onfido/exceptions.py
@@ -35,7 +35,13 @@ def error_decorator(func):
             if e.response.status_code >= 500:
                 raise OnfidoServerError() from e
             else:
-                raise OnfidoRequestError() from e
+                error = None
+                if e.response.status_code == 422:
+                    content_type = e.response.headers.get('Content-Type', '')
+                    if 'application/json' in content_type:
+                        resp_json = e.response.json()
+                        error = resp_json.get("error")
+                raise OnfidoRequestError(error) from e
 
         except requests.Timeout as e:
             raise OnfidoTimeoutError(e)


### PR DESCRIPTION
When uploading a live photo it is possible to set the
`advanced_validation` argument and have a synchronous error reporting
on the image, such as when there are no faces present in the image. [1]

However, `error_decorator()` would simply throw an `OnfidoRequestError`
exception without letting us know about the error, making it impossible
to derive (and request the user to re-take the image thereof).

The above is also true for the image quality check [2], getting the
error and checking it will allow servers that use the Onfido Python API
to request its users to re-take the image.

For example:
```Python
try:
    api.live_photo.upload(f, body)
except OnfidoRequestError as error:
    if error['fields']['face_detection']:
        print("No faces detected in image!")
    else:
        print("Unknown error in Onfido's response!")
        print(error)
```

1. https://documentation.onfido.com/#upload-live-photo
2. https://documentation.onfido.com/#image-quality