### PR TITLE
Resource: Use json instead of data in _upload_request

### DIFF
--- a/onfido/resource.py
+++ b/onfido/resource.py
@@ -44,7 +44,7 @@ class Resource:
             'file': (file.name, file, mimetype_from_name(file.name))
         }
         
-        response = requests.post(self._build_url(path), data=flat_nested_dict(request_body),
+        response = requests.post(self._build_url(path), json=flat_nested_dict(request_body),
                                  files=files, headers=self._headers, timeout=self._timeout)
 
         return self._handle_response(response)


### PR DESCRIPTION
**Edit: THIS IS NOT A VALID SOLUTION. See comment below.**

Using `data` causes the dictionary values to get repr'd rather than
translated to correct JSON values.

For example, the following body for a document upload request:
```
body = {
    'applicant_id': applicant_id,
    'type': 'driving_licence',
    'side': 'front',
    'validate_image_quality': True,
}
```

Will result in `validate_image_quality` to be set as `'True'` (a
string), rather than `true` (the JSON boolean value).

Onfido's backend doesn't expect a string in the form of `True`, causing
the validate_image_quality value to be ignored and the option is not
set.

This is also relevant for the live photo's upload `advanced_validation`
parameter. It is set to default but if you try to pass
`'advanced_validation': False` it will not get un-set.

The correct way to handle this and to avoid similar issues in the future
is to pass the body as JSON and let the requests library handle it, just
like it does for `_post()` and `_put()`.

