### PR TITLE
Fix boolean serialization in upload request

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## v2.4.1, 2nd Jun 2022
+
+- Fix boolean serialization in upload request ([issue #25](https://github.com/onfido/onfido-python/issues/25))
+
 ## v2.4.0, 12th May 2022
 
 - Update to use API v3.4, for more details please see our [release notes](https://developers.onfido.com/release-notes#api-v34)

--- a/onfido/resource.py
+++ b/onfido/resource.py
@@ -3,7 +3,7 @@ import requests
 from .onfido_download import OnfidoDownload
 from .exceptions import error_decorator, OnfidoUnknownError
 from .mimetype import mimetype_from_name
-from .utils import flat_nested_dict
+from .utils import form_data_converter
 
 
 CURRENT_VERSION = pkg_resources.get_distribution("onfido-python").version
@@ -44,7 +44,7 @@ class Resource:
             'file': (file.name, file, mimetype_from_name(file.name))
         }
         
-        response = requests.post(self._build_url(path), data=flat_nested_dict(request_body),
+        response = requests.post(self._build_url(path), data=form_data_converter(request_body),
                                  files=files, headers=self._headers, timeout=self._timeout)
 
         return self._handle_response(response)

--- a/onfido/utils.py
+++ b/onfido/utils.py
@@ -2,20 +2,21 @@
 def form_data_converter(data):
     """ Flat nested dictionary and stringify booleans for form-data """
 
+    def _converter(data, result, prefix=''):
+        if isinstance(data, dict):
+            for k, v in data.items():
+                pref = '{}[{}]'.format(prefix,k) if prefix else k
+                _converter(v, result, pref)
+        elif isinstance(data, bool):
+            result[prefix] = str(data).lower()
+        else:
+            result[prefix] = data
+
     # If no dict or booleans among values, no conversion needed
-    if not any(type(item) in (dict, bool) for item in data.values()):
+    if not any(isinstance(item, dict) or isinstance (item, bool) for item in data.values()):
         return data
 
     result = {}
-
-    # Perform needed conversion for each
-    for k, v in data.items():
-        if isinstance(v, dict):
-            for child_k, child_v in v.items():
-                result['{}[{}]'.format(k, child_k)] = child_v
-        elif isinstance(v, bool):
-            result[k] = str(v).lower()
-        else:
-            result[k] = v
+    _converter(data, result)
 
     return result

--- a/onfido/utils.py
+++ b/onfido/utils.py
@@ -10,10 +10,10 @@ def form_data_converter(data):
 
     # Perform needed conversion for each
     for k, v in data.items():
-        if type(v) is dict:
+        if isinstance(v, dict):
             for child_k, child_v in v.items():
                 result['{}[{}]'.format(k, child_k)] = child_v
-        elif type(v) is bool:
+        elif isinstance(v, bool):
             result[k] = str(v).lower()
         else:
             result[k] = v

--- a/onfido/utils.py
+++ b/onfido/utils.py
@@ -1,19 +1,21 @@
 
-def flat_nested_dict(data):
-    """ Flat nested dictionary """
+def form_data_converter(data):
+    """ Flat nested dictionary and stringify booleans for form-data """
 
-    # Check if any value is a dictionary
-    if any(type(item) is dict for item in data.values()):
-
-        # Start copying not nested values
-        result = {k: v for k, v in data.items() if type(v) is not dict}
-
-        # And add nested ones with proper format
-        for root_k, root_v in data.items():
-            if type(root_v) is dict:
-                for k, v in root_v.items():
-                    result['{}[{}]'.format(root_k, k)] = v
-
-        return result
-    else:
+    # If no dict or booleans among values, no conversion needed
+    if not any(type(item) in (dict, bool) for item in data.values()):
         return data
+
+    result = {}
+
+    # Perform needed conversion for each
+    for k, v in data.items():
+        if type(v) is dict:
+            for child_k, child_v in v.items():
+                result['{}[{}]'.format(k, child_k)] = child_v
+        elif type(v) is bool:
+            result[k] = str(v).lower()
+        else:
+            result[k] = v
+
+    return result

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -13,7 +13,7 @@ def test_upload_document(requests_mock):
     mock_upload = requests_mock.post("https://api.eu.onfido.com/v3.4/documents/", json=[])
 
     request_body = {"applicant_id": fake_uuid,
-                    "document_type": "driving_licence",
+                    "type": "driving_licence",
                     "location": {
                       "ip_address": "127.0.0.1",
                       "country_of_residence": "GBR"
@@ -46,7 +46,7 @@ def test_upload_document_validation_error(requests_mock):
 
     sample_file = open("sample_driving_licence.png", "rb")
     request_body = {"applicant_id": fake_uuid,
-                    "document_type": "driving_licence",
+                    "type": "driving_licence",
                     "validate_image_quality": True}
 
     with pytest.raises(OnfidoRequestError) as error:

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -17,7 +17,8 @@ def test_upload_document(requests_mock):
                     "location": {
                       "ip_address": "127.0.0.1",
                       "country_of_residence": "GBR"
-                      }
+                      },
+                    "validate_image_quality": True
                     }
 
     sample_file = open("sample_driving_licence.png", "rb")


### PR DESCRIPTION
As raised in issue #25, boolean values in upload request and not converted to proper JSON values but just stringified, which causes true values being written as `True` instead of `true`, that is later on interpreted as false at decode time. 

This is due to the fact that the form-data encoding is performed in such requests which uses string conversion instead of json. With this fix boolean conversion to string in performed in advance and includes a lowercase transformation.