### PR TITLE
Handle filenames with a uppercase file extension.

### DIFF
--- a/onfido/mimetype.py
+++ b/onfido/mimetype.py
@@ -1,6 +1,5 @@
 import mimetypes
-import os
 
 def mimetype_from_name(filename):
-    name, extension = os.path.splitext(filename)
-    return mimetypes.types_map[extension]
+    mimetype, _ = mimetypes.guess_type(filename)
+    return mimetype

--- a/tests/test_mimetypes.py
+++ b/tests/test_mimetypes.py
@@ -7,3 +7,7 @@ def test_mimetypes():
 
 def test_secondary_mimetypes():
     assert mimetype_from_name("filename.jpeg") == "image/jpeg"
+
+def test_uppercase():
+    """Uppercase file extensions are handled."""
+    assert mimetype_from_name("filename.JPG") == "image/jpeg"


### PR DESCRIPTION
Filenames with a uppercase file extension (example: mypassport.JPG) will cause a crash.

This PR makes `mimetype_from_name` into a one-line function - I thought about removing it entirely, but decided to leave it as it is.