### PR TITLE
Replace pkg_resources

### DIFF
--- a/onfido/resource.py
+++ b/onfido/resource.py
@@ -1,12 +1,15 @@
-import pkg_resources
 import requests
 from .onfido_download import OnfidoDownload
 from .exceptions import error_decorator, OnfidoUnknownError
 from .mimetype import mimetype_from_name
 from .utils import form_data_converter
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
-CURRENT_VERSION = pkg_resources.get_distribution("onfido-python").version
+CURRENT_VERSION = importlib_metadata.version("onfido-python")
 
 class Resource:
     def __init__(self, api_token, region, timeout):

--- a/poetry.lock
+++ b/poetry.lock
@@ -160,7 +160,7 @@ files = [
 name = "importlib-metadata"
 version = "1.7.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 files = [
@@ -499,7 +499,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "zipp"
 version = "3.1.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -514,4 +514,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.6,<4"
-content-hash = "0a42b8d350302daf23b168cc9c0bc578931e1669de4d9f3c506ac0c43706ee4b"
+content-hash = "0a89f11fcc699a5b3ed529f7ba0c1467720aa35ba7b3224816b3e3b83fbd7b80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.6,<4"
 requests = "^2.24.0"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
Importing pkg_resources is slow.

According to setuptools, use of pkg_resources is discouraged in favor of
importlib.metadata

`importlib.metadata` was introduced in Python 3.8 but there exists a
backport (`importlib_metadata`) for older versions of Python.

See: https://setuptools.pypa.io/en/latest/pkg_resources.html
