### PR TITLE
Add download signed PDF endpoint for workflow runs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## v2.9.0 24th November 2023
+
+- Added `signed_evidence_file` method for WorkflowRuns
+
 ## v2.8.0, 15th November 2023
 
 - Support asyncio API

--- a/onfido/onfido.py
+++ b/onfido/onfido.py
@@ -2,6 +2,7 @@ from .resources.applicants import Applicants
 from .resources.documents import Documents
 from .resources.address_picker import Addresses
 from .resources.checks import Checks
+from .resources.workflow_runs import WorkflowRuns
 from .resources.reports import Reports
 from .resources.live_photos import LivePhotos
 from .resources.live_videos import LiveVideos
@@ -17,6 +18,7 @@ from .resources_aio.applicants import Applicants as AsyncApplicants
 from .resources_aio.documents import Documents as AsyncDocuments
 from .resources_aio.address_picker import Addresses as AsyncAddresses
 from .resources_aio.checks import Checks as AsyncChecks
+from .resources_aio.workflow_runs import WorkflowRuns as AsyncWorkflowRuns
 from .resources_aio.reports import Reports as AsyncReports
 from .resources_aio.live_photos import LivePhotos as AsyncLivePhotos
 from .resources_aio.live_videos import LiveVideos as AsyncLiveVideos
@@ -40,6 +42,7 @@ class Api:
         self.motion_capture = MotionCaptures(api_token, region, timeout)
         self.extraction = Extraction(api_token, region, timeout)
         self.watchlist_monitor = WatchlistMonitors(api_token, region, timeout)
+        self.workflowrun = WorkflowRuns(api_token, region, timeout)
 
         if region in [Region.EU, Region.US, Region.CA]:
             pass
@@ -60,6 +63,7 @@ class AsyncApi:
         self.motion_capture = AsyncMotionCaptures(api_token, region, aio_session, timeout)
         self.extraction = AsyncExtraction(api_token, region, aio_session, timeout)
         self.watchlist_monitor = AsyncWatchlistMonitors(api_token, region, aio_session, timeout)
+        self.workflowrun = AsyncWorkflowRuns(api_token, region, aio_session, timeout)
 
         if region in [Region.EU, Region.US, Region.CA]:
             pass

--- a/onfido/resources/workflow_runs.py
+++ b/onfido/resources/workflow_runs.py
@@ -1,0 +1,6 @@
+from ..resource import Resource
+
+
+class WorkflowRuns(Resource):
+    def evidence(self, workflow_run_id: str):
+        return self._download_request(f"workflow_runs/{workflow_run_id}/signed_evidence_file")

--- a/onfido/resources_aio/workflow_runs.py
+++ b/onfido/resources_aio/workflow_runs.py
@@ -1,0 +1,6 @@
+from ..aio_resource import Resource
+
+
+class WorkflowRuns(Resource):
+    def evidence(self, workflow_run_id: str):
+        return self._download_request(f"workflow_runs/{workflow_run_id}/signed_evidence_file")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onfido-python"
-version = "2.8.1"
+version = "2.9.0"
 description = "The official wrapper for the Onfido API"
 homepage = "https://github.com/onfido/onfido-python"
 readme = "README.md"

--- a/tests/test_workflow_runs.py
+++ b/tests/test_workflow_runs.py
@@ -1,0 +1,13 @@
+import onfido
+from onfido.regions import Region
+
+
+api = onfido.Api("<AN_API_TOKEN>", region=Region.EU)
+
+fake_uuid = "58a9c6d2-8661-4dbd-96dc-b9b9d344a7ce"
+
+def test_evidence_workflowrun(requests_mock):
+    mock_download = requests_mock.get(f"https://api.eu.onfido.com/v3.6/workflow_runs/{fake_uuid}/signed_evidence_file", text="FAKE PDF BINARY", headers={"Content-type": "application/pdf"})
+    onfido_download = api.workflowrun.evidence(fake_uuid)
+    assert mock_download.called is True
+    assert onfido_download.content_type == "application/pdf"   


### PR DESCRIPTION
This adds [signed pdf download](https://documentation.onfido.com/#retrieve-workflow-run-signed-evidence-file) endpoint.