### PR TITLE
Refresh onfido-python after onfido-openapi-spec update (a34b6d8)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,12 +68,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: integration-tests
-    environment: delivery
     if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_ACTION_ACCESS_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -89,31 +86,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Update CHANGELOG.md
-        run: |
-          TMP_FILE=$(mktemp)
-
-          RELEASE_VERSION=$(jq -r '.release' .release.json)
-          RELEASE_DATE=`date +'%dth %B %Y' | sed -E 's/^0//;s/^([2,3]?)1th/\11st/;s/^([2]?)2th/\12nd/;s/^([2]?)3th/\13rd/'`
-
-          SPEC_COMMIT_SHA=$(jq -r '.source.short_sha' .release.json)
-          SPEC_COMMIT_URL=$(jq -r '.source.repo_url + "/commit/" + .source.long_sha' .release.json)
-          SPEC_RELEASE_VERSION=$(jq -r '.source.version' .release.json)
-          SPEC_RELEASE_URL=$(jq -r '.source.repo_url + "/releases/tag/" + .source.version' .release.json)
-
-          echo -e "# Changelog\n\n## $RELEASE_VERSION $RELEASE_DATE\n\n" >| $TMP_FILE
-          echo -en "${{ github.event.release.body }}\nBased on Onfido OpenAPI spec " >> $TMP_FILE
-
-          if [ -z $SPEC_RELEASE_VERSION ]; then
-            echo "up to commit [$SPEC_COMMIT_SHA](${SPEC_COMMIT_URL})." >> $TMP_FILE
-          else
-            echo "version [$SPEC_RELEASE_VERSION](${SPEC_RELEASE_URL})." >> $TMP_FILE
-          fi
-
-          grep -v "^# Changelog" CHANGELOG.md >> $TMP_FILE
-          mv $TMP_FILE CHANGELOG.md
-
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          git commit -m "Update CHANGELOG.md after library release" CHANGELOG.md
-          git push

--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "38a8740",
-    "long_sha": "38a87401552386cb0b17aae28385c5e2f4af7bfc",
-    "version": ""
+    "short_sha": "a34b6d8",
+    "long_sha": "a34b6d86714f7f74da2d60a33a76ec3a693d264a",
+    "version": "v3.0.0"
   },
-  "release": "v3.0.0"
+  "release": "v3.1.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v3.1.0 24th June 2024
+
+- Library has been rebuilt from scratch and automatically generated on [Onfido OpenAPI Spec](https://github.com/onfido/onfido-openapi-spec) (release [v3.0.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v3.0.0))
+- Integration tests have also been implemented
+
+## v3.0.0 13th June 2024 (pre-release)
+
+- Make library auto-generated and based on [Onfido OpenAPI spec](https://github.com/onfido/onfido-openapi-spec)
+
 ## v2.10.0 24th November 2023
 
 - Added core methods for [WorkflowRuns](https://documentation.onfido.com/#workflow-runs)

--- a/onfido/__init__.py
+++ b/onfido/__init__.py
@@ -14,7 +14,7 @@
 """  # noqa: E501
 
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 # import apis into sdk package
 from onfido.api.default_api import DefaultApi

--- a/onfido/api_client.py
+++ b/onfido/api_client.py
@@ -88,7 +88,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'onfido-python/3.0.0'
+        self.user_agent = 'onfido-python/3.1.0'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/onfido/configuration.py
+++ b/onfido/configuration.py
@@ -383,7 +383,7 @@ conf = onfido.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v3.6\n"\
-               "SDK Package Version: 3.0.0".\
+               "SDK Package Version: 3.1.0".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onfido-python"
-version = "3.0.0"
+version = "3.1.0"
 description = "Python library for the Onfido API"
 authors = ["OpenAPI Generator Community <team@openapitools.org>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 NAME = "onfido-python"
-VERSION = "3.0.0"
+VERSION = "3.1.0"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@a34b6d86714f7f74da2d60a33a76ec3a693d264a (included)

Additional changes:
  - [Update CHANGELOG (and remove step in charge of that from CI for now)](https://github.com/onfido/onfido-python/pull/62/commits/08789cebb2dc5395b836795612dc46ae527c5946)