### PR TITLE
[CAT-1120] Fix distribution package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Python 3.7+
 If the python package is hosted on a repository, you can install directly using:
 
 ```sh
-pip install onfido
+pip install onfido-python
 ```
 
 Then import the package:
@@ -31,7 +31,7 @@ import onfido
 #### Poetry
 
 ```sh
-poetry add onfido
+poetry add onfido-python
 ```
 
 Then import the package:


### PR DESCRIPTION
This fix is going to be persisted in https://github.com/onfido/onfido-openapi-spec/pull/94