### PR TITLE
Refresh onfido-python after onfido-openapi-spec update (40b86a1)

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "source": {
     "repo_url": "https://github.com/onfido/onfido-openapi-spec",
-    "short_sha": "01ed1b5",
-    "long_sha": "01ed1b5fe0f7490bfce54816504a9fec13b33862",
-    "version": "v3.1.0"
+    "short_sha": "40b86a1",
+    "long_sha": "40b86a1c8ec8687c15514470f60428b3e7633968",
+    "version": "v3.2.0"
   },
-  "release": "v3.2.0"
+  "release": "v3.3.0"
 }

--- a/onfido/__init__.py
+++ b/onfido/__init__.py
@@ -14,7 +14,7 @@
 """  # noqa: E501
 
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 # import apis into sdk package
 from onfido.api.default_api import DefaultApi

--- a/onfido/api/default_api.py
+++ b/onfido/api/default_api.py
@@ -5360,6 +5360,287 @@ class DefaultApi:
 
 
     @validate_call
+    def download_qes_document(
+        self,
+        workflow_run_id: Annotated[StrictStr, Field(description="The unique identifier of the Workflow Run for which you want to retrieve the signed document.")],
+        file_id: Annotated[StrictStr, Field(description="The unique identifier of the file which you want to retrieve.")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> bytearray:
+        """Retrieves the signed document or application form
+
+        Retrieves the signed document or application form depending on the file_id provided. 
+
+        :param workflow_run_id: The unique identifier of the Workflow Run for which you want to retrieve the signed document. (required)
+        :type workflow_run_id: str
+        :param file_id: The unique identifier of the file which you want to retrieve. (required)
+        :type file_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._download_qes_document_serialize(
+            workflow_run_id=workflow_run_id,
+            file_id=file_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '302': None,
+            '200': "bytearray",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def download_qes_document_with_http_info(
+        self,
+        workflow_run_id: Annotated[StrictStr, Field(description="The unique identifier of the Workflow Run for which you want to retrieve the signed document.")],
+        file_id: Annotated[StrictStr, Field(description="The unique identifier of the file which you want to retrieve.")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[bytearray]:
+        """Retrieves the signed document or application form
+
+        Retrieves the signed document or application form depending on the file_id provided. 
+
+        :param workflow_run_id: The unique identifier of the Workflow Run for which you want to retrieve the signed document. (required)
+        :type workflow_run_id: str
+        :param file_id: The unique identifier of the file which you want to retrieve. (required)
+        :type file_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._download_qes_document_serialize(
+            workflow_run_id=workflow_run_id,
+            file_id=file_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '302': None,
+            '200': "bytearray",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def download_qes_document_without_preload_content(
+        self,
+        workflow_run_id: Annotated[StrictStr, Field(description="The unique identifier of the Workflow Run for which you want to retrieve the signed document.")],
+        file_id: Annotated[StrictStr, Field(description="The unique identifier of the file which you want to retrieve.")],
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Retrieves the signed document or application form
+
+        Retrieves the signed document or application form depending on the file_id provided. 
+
+        :param workflow_run_id: The unique identifier of the Workflow Run for which you want to retrieve the signed document. (required)
+        :type workflow_run_id: str
+        :param file_id: The unique identifier of the file which you want to retrieve. (required)
+        :type file_id: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._download_qes_document_serialize(
+            workflow_run_id=workflow_run_id,
+            file_id=file_id,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '302': None,
+            '200': "bytearray",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _download_qes_document_serialize(
+        self,
+        workflow_run_id,
+        file_id,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, Union[str, bytes]] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        if workflow_run_id is not None:
+            
+            _query_params.append(('workflow_run_id', workflow_run_id))
+            
+        if file_id is not None:
+            
+            _query_params.append(('file_id', file_id))
+            
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/pdf', 
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+            'Token'
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/qualified_electronic_signature/documents',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def download_signed_evidence_file(
         self,
         workflow_run_id: Annotated[StrictStr, Field(description="Workflow Run ID")],

--- a/onfido/api_client.py
+++ b/onfido/api_client.py
@@ -88,7 +88,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'onfido-python/3.2.0'
+        self.user_agent = 'onfido-python/3.3.0'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/onfido/configuration.py
+++ b/onfido/configuration.py
@@ -383,7 +383,7 @@ conf = onfido.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v3.6\n"\
-               "SDK Package Version: 3.2.0".\
+               "SDK Package Version: 3.3.0".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/onfido/models/document.py
+++ b/onfido/models/document.py
@@ -48,8 +48,8 @@ class Document(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['jpg', 'png', 'pdf']):
-            raise ValueError("must be one of enum values ('jpg', 'png', 'pdf')")
+        if value not in set(['jpg', 'jpeg', 'png', 'pdf']):
+            raise ValueError("must be one of enum values ('jpg', 'jpeg', 'png', 'pdf')")
         return value
 
     @field_validator('side')

--- a/onfido/models/document_properties.py
+++ b/onfido/models/document_properties.py
@@ -40,9 +40,10 @@ class DocumentProperties(BaseModel):
     document_numbers: Optional[List[DocumentPropertiesDocumentNumbersInner]] = None
     document_type: Optional[StrictStr] = None
     first_name: Optional[StrictStr] = None
+    middle_name: Optional[StrictStr] = None
+    last_name: Optional[StrictStr] = None
     gender: Optional[StrictStr] = None
     issuing_country: Optional[StrictStr] = None
-    last_name: Optional[StrictStr] = None
     nationality: Optional[StrictStr] = None
     issuing_state: Optional[StrictStr] = None
     issuing_date: Optional[date] = None
@@ -79,7 +80,7 @@ class DocumentProperties(BaseModel):
     document_classification: Optional[DocumentPropertiesDocumentClassification] = None
     extracted_data: Optional[DocumentPropertiesExtractedData] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["date_of_birth", "date_of_expiry", "personal_number", "document_numbers", "document_type", "first_name", "gender", "issuing_country", "last_name", "nationality", "issuing_state", "issuing_date", "categorisation", "mrz_line1", "mrz_line2", "mrz_line3", "address", "place_of_birth", "spouse_name", "widow_name", "alias_name", "issuing_authority", "remarks", "civil_state", "expatriation", "father_name", "mother_name", "religion", "type_of_permit", "version_number", "document_subtype", "profession", "security_document_number", "tax_number", "nist_identity_evidence_strength", "has_issuance_confirmation", "real_id_compliance", "security_tier", "address_lines", "barcode", "nfc", "driving_licence_information", "document_classification", "extracted_data"]
+    __properties: ClassVar[List[str]] = ["date_of_birth", "date_of_expiry", "personal_number", "document_numbers", "document_type", "first_name", "middle_name", "last_name", "gender", "issuing_country", "nationality", "issuing_state", "issuing_date", "categorisation", "mrz_line1", "mrz_line2", "mrz_line3", "address", "place_of_birth", "spouse_name", "widow_name", "alias_name", "issuing_authority", "remarks", "civil_state", "expatriation", "father_name", "mother_name", "religion", "type_of_permit", "version_number", "document_subtype", "profession", "security_document_number", "tax_number", "nist_identity_evidence_strength", "has_issuance_confirmation", "real_id_compliance", "security_tier", "address_lines", "barcode", "nfc", "driving_licence_information", "document_classification", "extracted_data"]
 
     @field_validator('nist_identity_evidence_strength')
     def nist_identity_evidence_strength_validate_enum(cls, value):
@@ -204,9 +205,10 @@ class DocumentProperties(BaseModel):
             "document_numbers": [DocumentPropertiesDocumentNumbersInner.from_dict(_item) for _item in obj["document_numbers"]] if obj.get("document_numbers") is not None else None,
             "document_type": obj.get("document_type"),
             "first_name": obj.get("first_name"),
+            "middle_name": obj.get("middle_name"),
+            "last_name": obj.get("last_name"),
             "gender": obj.get("gender"),
             "issuing_country": obj.get("issuing_country"),
-            "last_name": obj.get("last_name"),
             "nationality": obj.get("nationality"),
             "issuing_state": obj.get("issuing_state"),
             "issuing_date": obj.get("issuing_date"),

--- a/onfido/models/document_shared.py
+++ b/onfido/models/document_shared.py
@@ -41,8 +41,8 @@ class DocumentShared(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['jpg', 'png', 'pdf']):
-            raise ValueError("must be one of enum values ('jpg', 'png', 'pdf')")
+        if value not in set(['jpg', 'jpeg', 'png', 'pdf']):
+            raise ValueError("must be one of enum values ('jpg', 'jpeg', 'png', 'pdf')")
         return value
 
     @field_validator('side')

--- a/onfido/models/document_with_driver_verification_report_all_of_properties.py
+++ b/onfido/models/document_with_driver_verification_report_all_of_properties.py
@@ -42,9 +42,10 @@ class DocumentWithDriverVerificationReportAllOfProperties(BaseModel):
     document_numbers: Optional[List[DocumentPropertiesDocumentNumbersInner]] = None
     document_type: Optional[StrictStr] = None
     first_name: Optional[StrictStr] = None
+    middle_name: Optional[StrictStr] = None
+    last_name: Optional[StrictStr] = None
     gender: Optional[StrictStr] = None
     issuing_country: Optional[StrictStr] = None
-    last_name: Optional[StrictStr] = None
     nationality: Optional[StrictStr] = None
     issuing_state: Optional[StrictStr] = None
     issuing_date: Optional[date] = None
@@ -87,7 +88,7 @@ class DocumentWithDriverVerificationReportAllOfProperties(BaseModel):
     vehicle_class_details: Optional[List[DocumentWithDriverVerificationReportAllOfPropertiesAllOfVehicleClassDetailsInner]] = Field(default=None, description="Detailed classes/categories information")
     passenger_vehicle: Optional[DocumentWithDriverVerificationReportAllOfPropertiesAllOfPassengerVehicle] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["date_of_birth", "date_of_expiry", "personal_number", "document_numbers", "document_type", "first_name", "gender", "issuing_country", "last_name", "nationality", "issuing_state", "issuing_date", "categorisation", "mrz_line1", "mrz_line2", "mrz_line3", "address", "place_of_birth", "spouse_name", "widow_name", "alias_name", "issuing_authority", "remarks", "civil_state", "expatriation", "father_name", "mother_name", "religion", "type_of_permit", "version_number", "document_subtype", "profession", "security_document_number", "tax_number", "nist_identity_evidence_strength", "has_issuance_confirmation", "real_id_compliance", "security_tier", "address_lines", "barcode", "nfc", "driving_licence_information", "document_classification", "extracted_data", "drivers_licence", "restricted_licence", "raw_licence_category", "raw_vehicle_classes", "vehicle_class_details", "passenger_vehicle"]
+    __properties: ClassVar[List[str]] = ["date_of_birth", "date_of_expiry", "personal_number", "document_numbers", "document_type", "first_name", "middle_name", "last_name", "gender", "issuing_country", "nationality", "issuing_state", "issuing_date", "categorisation", "mrz_line1", "mrz_line2", "mrz_line3", "address", "place_of_birth", "spouse_name", "widow_name", "alias_name", "issuing_authority", "remarks", "civil_state", "expatriation", "father_name", "mother_name", "religion", "type_of_permit", "version_number", "document_subtype", "profession", "security_document_number", "tax_number", "nist_identity_evidence_strength", "has_issuance_confirmation", "real_id_compliance", "security_tier", "address_lines", "barcode", "nfc", "driving_licence_information", "document_classification", "extracted_data", "drivers_licence", "restricted_licence", "raw_licence_category", "raw_vehicle_classes", "vehicle_class_details", "passenger_vehicle"]
 
     @field_validator('nist_identity_evidence_strength')
     def nist_identity_evidence_strength_validate_enum(cls, value):
@@ -222,9 +223,10 @@ class DocumentWithDriverVerificationReportAllOfProperties(BaseModel):
             "document_numbers": [DocumentPropertiesDocumentNumbersInner.from_dict(_item) for _item in obj["document_numbers"]] if obj.get("document_numbers") is not None else None,
             "document_type": obj.get("document_type"),
             "first_name": obj.get("first_name"),
+            "middle_name": obj.get("middle_name"),
+            "last_name": obj.get("last_name"),
             "gender": obj.get("gender"),
             "issuing_country": obj.get("issuing_country"),
-            "last_name": obj.get("last_name"),
             "nationality": obj.get("nationality"),
             "issuing_state": obj.get("issuing_state"),
             "issuing_date": obj.get("issuing_date"),

--- a/onfido/models/webhook_event_payload_object.py
+++ b/onfido/models/webhook_event_payload_object.py
@@ -29,10 +29,11 @@ class WebhookEventPayloadObject(BaseModel):
     """ # noqa: E501
     id: StrictStr = Field(description="The unique identifier of the resource.")
     status: Optional[StrictStr] = Field(default=None, description="The current state of the object, if available.")
+    started_at_iso8601: Optional[datetime] = Field(default=None, description="The date and time when the operation was started, if available.")
     completed_at_iso8601: Optional[datetime] = Field(default=None, description="The date and time when the operation was completed, if available.")
     href: StrictStr = Field(description="The uri of the resource.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "status", "completed_at_iso8601", "href"]
+    __properties: ClassVar[List[str]] = ["id", "status", "started_at_iso8601", "completed_at_iso8601", "href"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -94,6 +95,7 @@ class WebhookEventPayloadObject(BaseModel):
         _obj = cls.model_validate({
             "id": obj.get("id"),
             "status": obj.get("status"),
+            "started_at_iso8601": obj.get("started_at_iso8601"),
             "completed_at_iso8601": obj.get("completed_at_iso8601"),
             "href": obj.get("href")
         })

--- a/poetry.lock
+++ b/poetry.lock
@@ -38,13 +38,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.1"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
-    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onfido-python"
-version = "3.2.0"
+version = "3.3.0"
 description = "Python library for the Onfido API"
 authors = ["OpenAPI Generator Community <team@openapitools.org>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 NAME = "onfido-python"
-VERSION = "3.2.0"
+VERSION = "3.3.0"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,12 @@ def webhook_clean_up(onfido_api):
 def create_applicant(onfido_api, applicant_builder=None):
     if applicant_builder is None:
         return onfido_api.create_applicant(
-            onfido.ApplicantBuilder(first_name="First", last_name="Last")
+            onfido.ApplicantBuilder(
+                first_name="First",
+                last_name="Last",
+                email="first.last@gmail.com",
+                phone_number="351911111111",
+            )
         )
 
     return onfido_api.create_applicant(applicant_builder)
@@ -127,6 +132,24 @@ def repeat_request_until_status_changes(
             instance = function(*params).actual_instance
         else:
             instance = function(*params)
+
+    return instance
+
+
+def repeat_request_until_task_output_changes(
+    function, params, max_retries=10, sleep_time=1
+):
+    instance = function(*params)
+
+    iteration = 0
+    while instance.output == None:
+        if iteration > max_retries:
+            pytest.fail("Task output did not change in time")
+
+        iteration += 1
+        sleep(sleep_time)
+        
+        instance = function(*params)
 
     return instance
 

--- a/tests/test_qualified_electronic_signatures.py
+++ b/tests/test_qualified_electronic_signatures.py
@@ -1,0 +1,58 @@
+import pytest
+
+from onfido import WorkflowRunBuilder
+
+from tests.conftest import (
+    create_applicant,
+    create_workflow_run,
+    repeat_request_until_task_output_changes,
+)
+
+
+@pytest.fixture(scope="function")
+def applicant_id(onfido_api):
+    return create_applicant(onfido_api).id
+
+
+@pytest.fixture(scope="function")
+def workflow_id():
+    return "8b74614f-9e7f-42fd-852a-5f2bcc852587"
+
+
+@pytest.fixture(scope="function")
+def workflow_run(onfido_api, applicant_id, workflow_id):
+    workflow_run_builder = WorkflowRunBuilder(
+        applicant_id=applicant_id,
+        workflow_id=workflow_id,
+        custom_data={
+            "country_of_operation": "GBR",
+            "document_date_of_expiry": "2022-01-01",
+            "document_issuing_country": "FRA",
+            "document_issuing_date": "2022-01-01",
+            "document_number": "Example string",
+            "document_to_sign_url": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
+            "document_type": "driving_licence",
+        },
+    )
+    return create_workflow_run(
+        onfido_api, workflow_run_builder=workflow_run_builder
+    )
+
+
+@pytest.fixture(scope="function")
+def file_id(onfido_api, workflow_run):
+    
+    task = onfido_api.list_tasks(workflow_run.id)[0]
+
+    output = repeat_request_until_task_output_changes(
+        onfido_api.find_task, [workflow_run.id, task.id], max_retries=10, sleep_time=3
+    ).output
+
+    return output["properties"]["signed_documents"][0]["id"]
+
+
+def test_documents(onfido_api, workflow_run, file_id):
+    file = onfido_api.download_qes_document(workflow_run.id, file_id)
+
+    assert len(file) > 0
+    assert file[:4] == b"%PDF"


### PR DESCRIPTION
Auto-generated PR with changes till commit onfido/onfido-openapi-spec@40b86a1c8ec8687c15514470f60428b3e7633968 (included)

Additional changes:
  - [test(qes): cover document download](https://github.com/onfido/onfido-python/pull/68/commits/ede5cb4e2766a31a22404e4056de9e2da449a77a)