### PR TITLE
test: wait for evidence folder to be available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ def create_workflow_run(
 
 
 def repeat_request_until_status_changes(
-    function, params, status, max_retries=10, sleep_time=1
+    function, params, status, max_retries=15, sleep_time=1
 ):
     instance = function(*params)
 
@@ -138,7 +138,7 @@ def repeat_request_until_status_changes(
 
 
 def repeat_request_until_task_output_changes(
-    function, params, max_retries=10, sleep_time=1
+    function, params, max_retries=15, sleep_time=1
 ):
     instance = function(*params)
 
@@ -156,7 +156,7 @@ def repeat_request_until_task_output_changes(
 
 
 def repeat_request_until_http_code_changes(
-    function, params, max_retries=10, sleep_time=1
+    function, params, max_retries=15, sleep_time=1
 ):
     iteration = 0
     while iteration <= max_retries:

--- a/tests/test_workflow_runs.py
+++ b/tests/test_workflow_runs.py
@@ -2,7 +2,12 @@ import tempfile
 import zipfile
 import pytest
 
-from onfido import TimelineFileReference, WorkflowRun, WorkflowRunBuilder, WorkflowRunStatus
+from onfido import (
+    TimelineFileReference,
+    WorkflowRun,
+    WorkflowRunBuilder,
+    WorkflowRunStatus,
+)
 from tests.conftest import (
     create_applicant,
     create_workflow_run,
@@ -81,7 +86,9 @@ def test_download_evidence_folder(onfido_api, applicant_id):
         onfido_api.find_workflow_run, [workflow_run_id], WorkflowRunStatus.APPROVED
     )
 
-    file = onfido_api.download_evidence_folder(workflow_run_id)
+    file = repeat_request_until_http_code_changes(
+        onfido_api.download_evidence_folder, [workflow_run_id]
+    )
 
     assert len(file) > 0
     with tempfile.NamedTemporaryFile() as tmp_file:


### PR DESCRIPTION
Evidence folder needs to be available before it can be downloaded. Fix the test by retrying the request until we no longer receive 404.

I also did some extra changes (increasing number of retries) to reduce test flakiness.