### PR TITLE
Fix CHANGELOG.md and improve CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -56,7 +56,8 @@ jobs:
           poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude onfido
       - name: Test with pytest
         if: ${{ matrix.python-version == '3.13' &&
-          github.repository_owner == 'onfido' }}
+          github.repository_owner == 'onfido' &&
+          (github.event_name == 'pull_request' || github.event_name == 'release') }}
         run: |
           poetry run pytest --show-capture=no
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: "0 14 * * 0"   # Every Sunday, 2 hours after midday
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -72,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     environment: delivery
+    permissions:
+      contents: write
     if: github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 - Release based on Onfido OpenAPI spec version [v5.4.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.4.0):
   - [ENT-26] Add AES document download endpoint
 - Fix dependabot error, add support for python 3.13 (and drop 3.8)
+- [ENT-26] Add AES documents test
 
 ## v5.3.0 11th July 2025
 
-- Release based on Onfido OpenAPI spec version [v5.3.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.3.0):
 - Release based on Onfido OpenAPI spec version [v5.3.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.3.0):
   - [DEXTV2-9494] Add manual_transmission_restriction to document with driver verification report
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Release based on Onfido OpenAPI spec version [v5.4.0](https://github.com/onfido/onfido-openapi-spec/releases/tag/v5.4.0):
   - [ENT-26] Add AES document download endpoint
+- Fix dependabot error, add support for python 3.13 (and drop 3.8)
 
 ## v5.3.0 11th July 2025
 


### PR DESCRIPTION
Fix CHANGELOG.md and improve CI to not run tests when commit is not coming from a PR (i.e. CHANGELOG update performed by the CI).

Take the opportunity for fixing a few security vulnerabilities:
- https://github.com/onfido/onfido-python/security/code-scanning/6
- https://github.com/onfido/onfido-python/security/code-scanning/7