### PR TITLE
[CAT-2931] ci: add distributed lock for integration tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,10 +58,10 @@ jobs:
         id: should-run-integration-tests
         if: ${{ matrix.python-version == '3.13' &&
           github.repository_owner == 'onfido' }}
-        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
+        uses: onfido/onfido-actions/should-run-integration-tests@main
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@add-lock-action
+        uses: onfido/onfido-actions/lock/acquire@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
@@ -90,7 +90,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@add-lock-action
+        uses: onfido/onfido-actions/lock/release@main
         with:
           app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
           app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,12 +57,8 @@ jobs:
       - name: Should run integration tests
         id: should-run-integration-tests
         if: ${{ matrix.python-version == '3.13' &&
-          github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
+          github.repository_owner == 'onfido' }}
+        uses: onfido/onfido-actions/should-run-integration-tests@add-lock-action
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,13 +54,22 @@ jobs:
           poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude onfido
-      - name: Test with API token auth
+      - name: Should run integration tests
+        id: should-run-integration-tests
         if: ${{ matrix.python-version == '3.13' &&
           github.repository_owner == 'onfido' &&
           (github.event_name == 'pull_request' ||
            github.event_name == 'release' ||
            github.event_name == 'workflow_dispatch' ||
            github.event_name == 'schedule') }}
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+      - name: Acquire integration test lock
+        if: steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/acquire@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+      - name: Test with API token auth
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: |
           poetry run pytest --show-capture=no
         env:
@@ -71,12 +80,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Test with OAuth client credentials auth
-        if: ${{ matrix.python-version == '3.13' &&
-          github.repository_owner == 'onfido' &&
-          (github.event_name == 'pull_request' ||
-           github.event_name == 'release' ||
-           github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'schedule') }}
+        if: steps.should-run-integration-tests.outputs.result == 'true'
         run: |
           poetry run pytest --show-capture=no
         env:
@@ -87,6 +91,11 @@ jobs:
           ONFIDO_SAMPLE_VIDEO_ID_2: ${{ secrets.ONFIDO_SAMPLE_VIDEO_ID_2 }}
           ONFIDO_SAMPLE_MOTION_ID_1: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_1 }}
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
+      - name: Release integration test lock
+        if: always() && steps.should-run-integration-tests.outputs.result == 'true'
+        uses: onfido/onfido-actions/lock/release@main
+        with:
+          github-token: ${{ secrets.CI_LOCK_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,7 +63,8 @@ jobs:
         if: steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
       - name: Test with API token auth
         if: steps.should-run-integration-tests.outputs.result == 'true'
         run: |
@@ -91,7 +92,8 @@ jobs:
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
         uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
-          github-token: ${{ secrets.CI_LOCK_TOKEN }}
+          app-id: ${{ secrets.ONFIDO_CI_LOCK_APP_ID }}
+          app-private-key: ${{ secrets.ONFIDO_CI_LOCK_PRIVATE_KEY }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,7 +65,7 @@ jobs:
         run: echo "result=true" >> "$GITHUB_OUTPUT"
       - name: Acquire integration test lock
         if: steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/acquire@main
+        uses: onfido/onfido-actions/lock/acquire@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
       - name: Test with API token auth
@@ -93,7 +93,7 @@ jobs:
           ONFIDO_SAMPLE_MOTION_ID_2: ${{ secrets.ONFIDO_SAMPLE_MOTION_ID_2 }}
       - name: Release integration test lock
         if: always() && steps.should-run-integration-tests.outputs.result == 'true'
-        uses: onfido/onfido-actions/lock/release@main
+        uses: onfido/onfido-actions/lock/release@add-lock-action
         with:
           github-token: ${{ secrets.CI_LOCK_TOKEN }}
 


### PR DESCRIPTION
Prevents integration tests from running in parallel across SDK repositories by using a distributed lock via [onfido-actions/lock](https://github.com/onfido/onfido-actions).

**Changes:**
- Add `should-run-integration-tests` action to determine when tests should run
- Acquire/release a cross-repo lock around integration tests